### PR TITLE
Joystick deadzone increase and fullscreen toggling

### DIFF
--- a/systemstub_sdl.cpp
+++ b/systemstub_sdl.cpp
@@ -28,7 +28,7 @@ struct SystemStub_SDL : SystemStub {
 	enum {
 		MAX_BLIT_RECTS = 200,
 		SOUND_SAMPLE_RATE = 22050,
-		JOYSTICK_COMMIT_VALUE = 3200
+		JOYSTICK_COMMIT_VALUE = 8000
 	};
 
 	uint16_t *_screenBuffer;

--- a/systemstub_sdl.cpp
+++ b/systemstub_sdl.cpp
@@ -485,7 +485,7 @@ while (true) {
 			break;
 		case SDL_KEYDOWN:
 			if (ev.key.keysym.mod & KMOD_ALT) {
-				if (ev.key.keysym.sym == SDLK_RETURN) {
+				if (ev.key.keysym.sym == SDLK_RETURN || ev.key.keysym.sym == SDLK_f) {
 					switchGfxMode(!_fullscreen, _currentScaler);
 				} else if (ev.key.keysym.sym == SDLK_KP_PLUS || ev.key.keysym.sym == SDLK_PAGEUP) {
 #ifdef USE_GL


### PR DESCRIPTION
The Xbox360 controller would register inputs when the directional axis wasn't touched, increasing the deadzone to 8000 fixes this issue.
Switching to fullscreen with Alt+Enter didn't work for some reason so I added an alternate shortcut (Alt+F) which works. Strangely, Alt+Enter works fine for switching back to windowed.